### PR TITLE
enhan/ nginx Dockerfile 수정

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,5 @@
 version: '3.9'
 services:
-
   nginx:
     build: ./nginx
     volumes:
@@ -9,20 +8,16 @@ services:
       - 80:80
     depends_on:
       - app
-### 이하 app 컨테이너는 생략###
+
   app:
     build: .
     volumes:
       - .:/django
-    ports:
-      - 8000:8000
     image: app:django
     container_name: django_container
     env_file:
       - ./.env
-      # env 파일 지정 필요
     command: gunicorn posting_service.wsgi:application --bind 0.0.0.0:8000
-    expose:
-      - 8000
+
 volumes:
   static_volume:

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,2 +1,2 @@
 FROM nginx:1.22.0-alpine
-COPY nginx.conf etc/nginx/conf.d
+COPY nginx.conf etc/nginx/conf.d/default.conf


### PR DESCRIPTION
nginx container에서 경로를 conf.d로 복사를 하려고 했으나, 기본적으로 생성되는 default.conf가 덮어 씌워졌기 때문에 404 Error 발생
해결 방안:
nginx의 컨테이너에 들어가서 conf.d의 폴더내부를 확인 해 보니 conf.d와 default가 있는 것을 확인하여 덮어 씌워져 있는것을 확인하였고, copy 경로 뒤에 default를 추가해줌
기존코드 :
```
FROM nginx:1.22.0-alpine
COPY nginx.conf etc/nginx/conf.d
```
수정코드:
```
FROM nginx:1.22.0-alpine
COPY nginx.conf etc/nginx/conf.d/default.conf
```

![image](https://user-images.githubusercontent.com/101394490/194291266-024112d3-4253-4ecd-82ef-c1bffb8b0899.png)
